### PR TITLE
Normalize JDBC paths and enhance CI memory safety workflow

### DIFF
--- a/.github/workflows/benchmark-assets.yml
+++ b/.github/workflows/benchmark-assets.yml
@@ -106,34 +106,27 @@ jobs:
               enabled: true
             decentdb:
               enabled: true
-              temp_dir: .tmp/benchmark-assets/decentdb-tmp
+              temp_dir: ${GITHUB_WORKSPACE}/.tmp/benchmark-assets/decentdb-tmp
             h2:
               enabled: true
               jdbc_url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
               driver_class: org.h2.Driver
               jar_paths:
-                - .tmp/benchmark-assets/jars/h2.jar
+                - ${GITHUB_WORKSPACE}/.tmp/benchmark-assets/jars/h2.jar
             derby:
               enabled: true
               jdbc_url: jdbc:derby:{db_path};create=true
               driver_class: org.apache.derby.iapi.jdbc.AutoloadedDriver
               jar_paths:
-                - .tmp/benchmark-assets/jars/derby.jar
-                - .tmp/benchmark-assets/jars/derbyshared.jar
+                - ${GITHUB_WORKSPACE}/.tmp/benchmark-assets/jars/derby.jar
+                - ${GITHUB_WORKSPACE}/.tmp/benchmark-assets/jars/derbyshared.jar
             hsqldb:
               enabled: true
               jdbc_url: jdbc:hsqldb:file:{db_path};hsqldb.write_delay=false
               driver_class: org.hsqldb.jdbc.JDBCDriver
               jar_paths:
-                - .tmp/benchmark-assets/jars/hsqldb.jar
+                - ${GITHUB_WORKSPACE}/.tmp/benchmark-assets/jars/hsqldb.jar
           EOF
-
-      - name: Preserve benchmark markdown baseline
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p .tmp/benchmark-assets/original
-          cp docs/user-guide/benchmarks.md .tmp/benchmark-assets/original/benchmarks.md
 
       - name: Build release native library
         shell: bash
@@ -287,17 +280,6 @@ jobs:
                   )
                   sys.exit(1)
           PY
-
-      - name: Restore benchmark markdown when only timestamp changed
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --no-index --quiet \
-            --ignore-matching-lines='^- Document updated:' \
-            .tmp/benchmark-assets/original/benchmarks.md \
-            docs/user-guide/benchmarks.md; then
-            cp .tmp/benchmark-assets/original/benchmarks.md docs/user-guide/benchmarks.md
-          fi
 
       - name: Prepare root README comparison subset
         shell: bash

--- a/.github/workflows/memory-safety-nightly.yml
+++ b/.github/workflows/memory-safety-nightly.yml
@@ -196,13 +196,22 @@ jobs:
         if: matrix.binding != 'java'
         run: cargo build -p decentdb --quiet
 
+      - name: Build CLI (debug)
+        if: matrix.binding == 'dotnet'
+        run: cargo build -p decentdb-cli --quiet
+
       - name: Build native library (release)
         if: matrix.binding == 'java'
         run: cargo build -p decentdb --release --quiet
 
+      - name: Prepare DBeaver plugin dir
+        if: matrix.binding == 'java'
+        run: mkdir -p .tmp/dbeaver/plugins
+
       - name: Run .NET lifecycle and leak coverage
         if: matrix.binding == 'dotnet'
         run: |
+          export PATH="${GITHUB_WORKSPACE}/target/debug:$PATH"
           cd bindings/dotnet
           dotnet test DecentDB.NET.sln -v minimal
           dotnet test tests/DecentDB.Tests/DecentDB.Tests.csproj -v minimal --filter FullyQualifiedName~MemoryLeakTests
@@ -216,10 +225,12 @@ jobs:
 
       - name: Run Java lifecycle and leak coverage
         if: matrix.binding == 'java'
+        env:
+          DBEAVER_PLUGIN_DIR: ${{ github.workspace }}/.tmp/dbeaver/plugins
         run: |
           cd bindings/java
-          ./gradlew --no-daemon :driver:test -PnativeLibDir="${GITHUB_WORKSPACE}/target/release"
-          ./gradlew --no-daemon :driver:test --tests com.decentdb.jdbc.MemoryLeakTest -PnativeLibDir="${GITHUB_WORKSPACE}/target/release"
+          ./gradlew --no-daemon :driver:test -PnativeLibDir="${GITHUB_WORKSPACE}/target/release" -PdbeaverPluginDir="${DBEAVER_PLUGIN_DIR}"
+          ./gradlew --no-daemon :driver:test --tests com.decentdb.jdbc.MemoryLeakTest -PnativeLibDir="${GITHUB_WORKSPACE}/target/release" -PdbeaverPluginDir="${DBEAVER_PLUGIN_DIR}"
 
       - name: Run Node lifecycle and leak coverage
         if: matrix.binding == 'node'
@@ -241,4 +252,4 @@ jobs:
           cd bindings/dart/dart
           dart pub get
           dart test --reporter expanded
-          dart test --reporter expanded test/memory_leak_test.dart --concurrency=1
+          DECENTDB_RUN_MEMORY_LEAK_TEST=1 dart test --reporter expanded test/memory_leak_test.dart --concurrency=1

--- a/benchmarks/python_embedded_compare/drivers/jdbc_driver.py
+++ b/benchmarks/python_embedded_compare/drivers/jdbc_driver.py
@@ -6,6 +6,7 @@ Note: JVM-based engines will have Python-to-Java bridge overhead.
 
 import os
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from drivers.base_driver import BenchmarkMetrics, DatabaseDriver, EngineMetadata
@@ -59,7 +60,7 @@ class JDBCDriver(DatabaseDriver):
         self.db_path = config.get("database_path", "mem:test")
         self.jdbc_url = config.get("jdbc_url", "")
         self.driver_class = config.get("driver_class", "")
-        self.jar_paths = config.get("jar_paths", [])
+        self.jar_paths = self._normalize_jar_paths(config.get("jar_paths", []))
         self.connection_properties = dict(config.get("connection_properties", {}))
         self.jvm_properties = dict(config.get("jvm_properties", {}))
         self._prepared_stmts: Dict[str, Any] = {}
@@ -75,7 +76,14 @@ class JDBCDriver(DatabaseDriver):
             if not self.driver_class:
                 self.driver_class = eng_cfg["driver_class"]
             if not self.jar_paths and eng_cfg.get("jar_path"):
-                self.jar_paths = [eng_cfg["jar_path"]]
+                self.jar_paths = self._normalize_jar_paths([eng_cfg["jar_path"]])
+
+    def _normalize_jar_paths(self, jar_paths: List[str]) -> List[str]:
+        normalized: List[str] = []
+        for jar_path in jar_paths:
+            path = Path(jar_path).expanduser()
+            normalized.append(str(path.resolve()) if not path.is_absolute() else str(path))
+        return normalized
 
     def _resolve_jdbc_url(self, jdbc_url: str) -> str:
         if "{db_path}" in jdbc_url:
@@ -121,7 +129,7 @@ class JDBCDriver(DatabaseDriver):
             return False
 
         try:
-            classpath = ":".join(self.jar_paths) if self.jar_paths else None
+            classpath = os.pathsep.join(self.jar_paths) if self.jar_paths else None
 
             if JPYPE_AVAILABLE:
                 if not jpype.isJVMStarted():

--- a/benchmarks/python_embedded_compare/tests/test_smoke.py
+++ b/benchmarks/python_embedded_compare/tests/test_smoke.py
@@ -196,6 +196,25 @@ class TestJdbcDriverConfig:
         assert "DB_CLOSE_DELAY=-1" in driver.jdbc_url
         assert "run_123" in driver.jdbc_url
 
+    def test_jdbc_driver_normalizes_relative_jar_paths(self, tmp_path, monkeypatch):
+        """Relative JDBC jar paths should be normalized before JPype sees them."""
+        jars_dir = tmp_path / "jars"
+        jars_dir.mkdir()
+        jar_path = jars_dir / "h2.jar"
+        jar_path.write_text("", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        driver = JDBCDriver(
+            {
+                "engine": "h2",
+                "database_path": "/tmp/run-123/h2.db",
+                "jdbc_url": "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",
+                "jar_paths": ["jars/h2.jar"],
+            }
+        )
+
+        assert driver.jar_paths == [str(jar_path.resolve())]
+
     def test_firebird_driver_adds_native_support_jars(self):
         """Firebird driver should include bundled Jaybird native support jars."""
         driver = FirebirdDriver(

--- a/bindings/dart/dart/test/memory_leak_test.dart
+++ b/bindings/dart/dart/test/memory_leak_test.dart
@@ -34,6 +34,8 @@ String findNativeLib() {
 typedef _MallocTrimNative = Int32 Function(IntPtr);
 typedef _MallocTrimDart = int Function(int);
 
+const _runMemoryLeakEnv = 'DECENTDB_RUN_MEMORY_LEAK_TEST';
+
 int rssBytes() => ProcessInfo.currentRss;
 
 bool trimProcessHeap() {
@@ -49,6 +51,19 @@ bool trimProcessHeap() {
   } on Object {
     return false;
   }
+}
+
+String? memoryLeakSkipReason() {
+  if (!Platform.isLinux) {
+    return 'RSS leak regression is Linux-specific';
+  }
+
+  final enabled = Platform.environment[_runMemoryLeakEnv];
+  if (enabled == '1' || enabled?.toLowerCase() == 'true') {
+    return null;
+  }
+
+  return 'Run with $_runMemoryLeakEnv=1 in an isolated dart test process';
 }
 
 void main() {
@@ -116,6 +131,7 @@ void main() {
         tempDir.deleteSync(recursive: true);
       }
     },
-    skip: Platform.isLinux ? false : 'RSS leak regression is Linux-specific',
+    // This measures process-wide RSS, so keep it out of the default suite run.
+    skip: memoryLeakSkipReason(),
   );
 }

--- a/crates/decentdb/src/db.rs
+++ b/crates/decentdb/src/db.rs
@@ -3688,6 +3688,28 @@ mod tests {
     }
 
     #[test]
+    fn shared_wal_registry_entry_is_removed_when_last_handle_drops() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = tempdir.path().join("shared-wal-registry-cleanup.ddb");
+        let db = Db::open_or_create(&path, DbConfig::default()).expect("open db");
+        db.execute("CREATE TABLE t (id INTEGER)")
+            .expect("create table");
+
+        let canonical_path = crate::vfs::VfsHandle::for_path(&path)
+            .canonicalize_path(&path)
+            .expect("canonicalize path");
+        assert!(crate::wal::shared::has_registry_entry_for_tests(
+            &canonical_path
+        ));
+
+        drop(db);
+
+        assert!(!crate::wal::shared::has_registry_entry_for_tests(
+            &canonical_path
+        ));
+    }
+
+    #[test]
     fn checkpoint_preserves_unchanged_table_payload_pages() {
         let tempdir = TempDir::new().expect("tempdir");
         let path = tempdir

--- a/crates/decentdb/src/wal/shared.rs
+++ b/crates/decentdb/src/wal/shared.rs
@@ -102,15 +102,46 @@ fn registry() -> &'static Mutex<HashMap<PathBuf, Weak<SharedWalInner>>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+#[cfg(test)]
+pub(crate) fn has_registry_entry_for_tests(path: &Path) -> bool {
+    registry()
+        .lock()
+        .expect("shared wal registry lock should not be poisoned")
+        .contains_key(path)
+}
+
+impl Drop for SharedWalInner {
+    fn drop(&mut self) {
+        let Some(canonical_path) = self.canonical_path.as_ref() else {
+            return;
+        };
+        let mut registry = registry()
+            .lock()
+            .expect("shared wal registry lock should not be poisoned");
+        let should_remove = registry
+            .get(canonical_path)
+            .is_some_and(|entry| entry.upgrade().is_none());
+        if should_remove {
+            registry.remove(canonical_path);
+            if registry.is_empty() {
+                registry.shrink_to_fit();
+            }
+        }
+    }
+}
+
 pub(crate) fn evict(vfs: &VfsHandle, db_path: &Path) -> Result<()> {
     if vfs.is_memory() {
         return Ok(());
     }
 
     let canonical_path = vfs.canonicalize_path(db_path)?;
-    registry()
+    let mut registry = registry()
         .lock()
-        .expect("shared wal registry lock should not be poisoned")
-        .remove(&canonical_path);
+        .expect("shared wal registry lock should not be poisoned");
+    registry.remove(&canonical_path);
+    if registry.is_empty() {
+        registry.shrink_to_fit();
+    }
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the benchmarking infrastructure, test reliability, and core database code. The main themes are: ensuring robust path handling for JDBC drivers, improving memory leak test isolation, and fixing a resource cleanup bug in the database's shared WAL registry. Additionally, some workflow steps were streamlined or improved for clarity and correctness.

**Path handling and workflow improvements:**

- Updated all JDBC `jar_paths` in `.github/workflows/benchmark-assets.yml` to use absolute paths based on `${GITHUB_WORKSPACE}` to avoid issues with relative paths in CI environments.
- The Python JDBC driver now normalizes all `jar_paths` to absolute paths using `pathlib`, ensuring JPype is always given fully resolved paths. A test was added to verify this normalization. [[1]](diffhunk://#diff-8c38547d143bc2dd97d4f1affe21b23054780f1288739370242c5b130c8663b9R9) [[2]](diffhunk://#diff-8c38547d143bc2dd97d4f1affe21b23054780f1288739370242c5b130c8663b9L62-R63) [[3]](diffhunk://#diff-8c38547d143bc2dd97d4f1affe21b23054780f1288739370242c5b130c8663b9L78-R86) [[4]](diffhunk://#diff-8c38547d143bc2dd97d4f1affe21b23054780f1288739370242c5b130c8663b9L124-R132) [[5]](diffhunk://#diff-5fce6037c91bdc8f1ab6849c44643890eaa316180195bd784b63857f56bcde2dR199-R217)

**Test isolation and reliability:**

- Dart memory leak tests now require the environment variable `DECENTDB_RUN_MEMORY_LEAK_TEST` to be set, preventing accidental execution during default test runs and clarifying platform-specific skip reasons. [[1]](diffhunk://#diff-972aaf64285b66c2fc3db885d0acc5a0676efceb6a3b40badae9aee115cbd79aR37-R38) [[2]](diffhunk://#diff-972aaf64285b66c2fc3db885d0acc5a0676efceb6a3b40badae9aee115cbd79aR56-R68) [[3]](diffhunk://#diff-972aaf64285b66c2fc3db885d0acc5a0676efceb6a3b40badae9aee115cbd79aL119-R135)
- The Dart workflow step was updated to set this environment variable only for the memory leak test.

**Database resource cleanup:**

- Fixed a bug in the Rust `SharedWalInner` implementation: the shared WAL registry now removes entries when the last handle drops, preventing resource leaks. Added a test to verify this cleanup. [[1]](diffhunk://#diff-902e03677f704a93872b73dd05fea6c81894c66baaed87430ec3eb4adc4f0985R3690-R3711) [[2]](diffhunk://#diff-e9a7586379239e98efe9640cabdc4674fe5f3939a726a87502fbfd24c7ed36bfR105-R145)

**Workflow maintenance and simplification:**

- Removed unnecessary steps from the benchmark workflow that preserved and restored the markdown baseline, streamlining the CI process.
- Added steps to build the CLI for .NET and to prepare the DBeaver plugin directory for Java in the nightly memory safety workflow, improving test coverage and plugin support. [[1]](diffhunk://#diff-ef065d01eca2e63732fdf8d6800f3fc7de2acde1d258add525acf62d23511d5fR199-R214) [[2]](diffhunk://#diff-ef065d01eca2e63732fdf8d6800f3fc7de2acde1d258add525acf62d23511d5fR228-R233)