### PR TITLE
Add Firebird driver support checks to smoke tests

### DIFF
--- a/benchmarks/python_embedded_compare/tests/test_smoke.py
+++ b/benchmarks/python_embedded_compare/tests/test_smoke.py
@@ -13,6 +13,16 @@ import pytest
 from drivers.jdbc_driver import JDBCDriver
 from drivers.sqlite_driver import SQLiteDriver
 from drivers.firebird_driver import FirebirdDriver
+
+_VENDOR_DIR = Path(__file__).resolve().parents[1] / "vendor"
+_HAS_FIREBIRD_JARS = all(
+    (_VENDOR_DIR / j).exists()
+    for j in ("jaybird-native-6.0.4.jar", "jna-jpms-5.18.1.jar")
+)
+_skip_no_firebird = pytest.mark.skipif(
+    not _HAS_FIREBIRD_JARS,
+    reason="Firebird vendor JARs not present in vendor/",
+)
 from utils.charting import _decentdb_rank_summary, _engine_sort_key
 
 try:
@@ -215,6 +225,7 @@ class TestJdbcDriverConfig:
 
         assert driver.jar_paths == [str(jar_path.resolve())]
 
+    @_skip_no_firebird
     def test_firebird_driver_adds_native_support_jars(self):
         """Firebird driver should include bundled Jaybird native support jars."""
         driver = FirebirdDriver(
@@ -232,6 +243,7 @@ class TestJdbcDriverConfig:
         assert driver.connection_properties["user"] == "SYSDBA"
         assert driver.connection_properties["password"] == "masterkey"
 
+    @_skip_no_firebird
     def test_firebird_driver_creates_shim_for_versioned_fbclient(self, tmp_path):
         """Firebird driver should expose versioned fbclient as libfbclient.so."""
         versioned_lib = tmp_path / "libfbclient.so.2"


### PR DESCRIPTION
This pull request improves the reliability of Firebird-related tests in `test_smoke.py` by conditionally skipping them when required vendor JAR files are not present. This prevents test failures in environments where Firebird dependencies are missing.

**Test reliability improvements:**

* Introduced a check for the presence of required Firebird JAR files (`jaybird-native-6.0.4.jar` and `jna-jpms-5.18.1.jar`) in the `vendor` directory, and defined a `_skip_no_firebird` marker to skip related tests if they are missing.
* Applied the `_skip_no_firebird` marker to `test_firebird_driver_adds_native_support_jars` and `test_firebird_driver_creates_shim_for_versioned_fbclient` to ensure these tests are skipped when dependencies are absent. [[1]](diffhunk://#diff-5fce6037c91bdc8f1ab6849c44643890eaa316180195bd784b63857f56bcde2dR228) [[2]](diffhunk://#diff-5fce6037c91bdc8f1ab6849c44643890eaa316180195bd784b63857f56bcde2dR246)