### PR TITLE
Reduce timeout for Rust Miri job and add smoke binary for testing

### DIFF
--- a/.github/workflows/memory-safety-nightly.yml
+++ b/.github/workflows/memory-safety-nightly.yml
@@ -52,7 +52,7 @@ jobs:
   rust-miri:
     name: Rust Miri (Undefined Behavior)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -66,12 +66,13 @@ jobs:
       - name: Setup Miri
         run: cargo miri setup
 
-      - name: Run Miri smoke tests
-        # Running the full engine test corpus under Miri is too slow for the
-        # nightly CI timeout budget. Keep this target limited to a curated smoke
-        # suite that exercises low-level pager/WAL/snapshot/failpoint paths
-        # without going through SQL parser FFI that Miri cannot execute.
-        run: cargo miri test -p decentdb --test miri_smoke_tests -- --test-threads=1
+      - name: Run Miri smoke binary
+        # Integration-test targets pull in the crate dev-dependency graph under
+        # Miri, which includes heavy benchmark/comparison crates that are not
+        # relevant to UB checking here. Run a tiny binary target instead so the
+        # nightly lane stays focused on a minimal pager/WAL/snapshot/rollback
+        # path and fits the tighter 30-minute budget.
+        run: cargo miri run -p decentdb --bin miri_smoke
 
   python-leak-regressions:
     name: Python Leak Regressions

--- a/crates/decentdb/src/bin/miri_smoke.rs
+++ b/crates/decentdb/src/bin/miri_smoke.rs
@@ -1,0 +1,42 @@
+use decentdb::{Db, DbConfig, Result};
+
+fn miri_db() -> Result<Db> {
+    // Miri interprets every operation, so keep the cache at the minimum
+    // effective size while still exercising the real pager/WAL code paths.
+    let config = DbConfig {
+        cache_size_mb: 0,
+        ..DbConfig::default()
+    };
+    Db::open_or_create(":memory:", config)
+}
+
+fn page_image(page_size: u32, marker: u8) -> Vec<u8> {
+    let mut page = vec![0_u8; page_size as usize];
+    page[0] = marker;
+    page
+}
+
+fn main() -> Result<()> {
+    let db = miri_db()?;
+    let original = page_image(db.config().page_size, 0x11);
+    let replacement = page_image(db.config().page_size, 0x22);
+
+    db.begin_write()?;
+    db.write_page(3, &original)?;
+    db.commit()?;
+
+    let snapshot = db.hold_snapshot()?;
+    assert_eq!(db.storage_info()?.active_readers, 1);
+
+    db.begin_write()?;
+    db.write_page(3, &replacement)?;
+    db.rollback()?;
+
+    assert_eq!(db.read_page(3)?.to_vec(), original);
+    assert_eq!(db.read_page_for_snapshot(snapshot, 3)?.to_vec(), original);
+
+    db.release_snapshot(snapshot)?;
+    assert_eq!(db.storage_info()?.active_readers, 0);
+
+    Ok(())
+}

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -3,6 +3,20 @@
 Release readiness is gated through the Phase 4 workflows, benchmark binary, and
 binding matrix.
 
+## Triggering the GitHub release workflow
+
+The GitHub release workflow in `.github/workflows/release.yml` auto-starts when
+a version tag is pushed to the repository:
+
+```bash
+git push origin vX.Y.Z
+```
+
+That workflow currently listens to `push` events for `v*` tags. Creating a tag
+or publishing a release from the GitHub UI does not reliably go through that
+same event path, so if a tag is created server-side you may need to use
+`workflow_dispatch` to run the release pipeline manually.
+
 ## CI lanes
 
 - `CI`: `.github/workflows/ci.yml`


### PR DESCRIPTION
This pull request updates the nightly memory safety workflow and clarifies the release process documentation. The main changes include optimizing the Miri job for faster execution and providing clear instructions on how to trigger the GitHub release workflow.

**Workflow optimizations:**

* Reduced the `rust-miri` job timeout from 60 to 30 minutes in `.github/workflows/memory-safety-nightly.yml` to better fit CI constraints.
* Changed the Miri test step to run a minimal binary (`miri_smoke`) instead of the full test suite, ensuring the job remains focused and fits within the reduced timeout.

**Documentation improvements:**

* Added a new section to `docs/development/releases.md` explaining how to trigger the GitHub release workflow, including the correct way to push tags and caveats about using the GitHub UI.…ocused testing