### PR TITLE
Enhance NuGet workflow with optional publishing and documentation

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -10,6 +10,11 @@ on:
         description: Existing release tag to publish (for example v2.1.0)
         required: true
         type: string
+      publish_to_nuget:
+        description: Push the built packages to NuGet.org after validation
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -79,7 +84,7 @@ jobs:
           path: out/
 
   pack-and-push:
-    name: Pack + publish NuGet.org
+    name: Pack + optional NuGet.org publish
     runs-on: ubuntu-latest
     needs: [build-native]
     env:
@@ -232,6 +237,7 @@ jobs:
           unzip -l "$pkg" | grep -q "lib/net10.0/DecentDB.EntityFrameworkCore.NodaTime.dll"
 
       - name: Publish to NuGet.org
+        if: ${{ github.event_name == 'push' || inputs.publish_to_nuget == true }}
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         shell: bash
@@ -246,3 +252,7 @@ jobs:
             echo "NUGET_API_KEY not set, skipping NuGet.org publish"
             exit 1
           fi
+
+      - name: Confirm dry-run package validation
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_to_nuget != true }}
+        run: echo "Validated and packed release artifacts without publishing to NuGet.org."

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -17,6 +17,17 @@ or publishing a release from the GitHub UI does not reliably go through that
 same event path, so if a tag is created server-side you may need to use
 `workflow_dispatch` to run the release pipeline manually.
 
+The NuGet workflow in `.github/workflows/nuget.yml` also supports
+`workflow_dispatch`, but it should be started from `main`, not from the tag
+itself, with:
+
+- `release_tag` set to the existing release tag, such as `v2.1.0`
+- `publish_to_nuget` left at `false` for a safe dry run that builds, packs, and
+  verifies package contents without publishing
+
+Set `publish_to_nuget` to `true` only when you intentionally want that manual
+run to push packages to NuGet.org.
+
 ## CI lanes
 
 - `CI`: `.github/workflows/ci.yml`


### PR DESCRIPTION
This pull request updates the NuGet publishing workflow to support both dry-run validations and optional publishing to NuGet.org, improving safety and flexibility for release management. It introduces a new input to control publishing behavior and clarifies usage in the documentation.

**NuGet workflow improvements:**

* Added a `publish_to_nuget` boolean input to `.github/workflows/nuget.yml`, allowing users to choose between a dry run (validation only) and actual publishing to NuGet.org.
* Updated the workflow to only publish to NuGet.org if triggered by a `push` event or if `publish_to_nuget` is set to `true`; otherwise, it performs a dry run and confirms validation without publishing. [[1]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R240) [[2]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R255-R258)
* Changed the workflow job name to reflect optional publishing, making the workflow intent clearer.

**Documentation updates:**

* Clarified in `docs/development/releases.md` how to use the new workflow options, including instructions for safe dry runs and explicit publishing.…on updates