### PR TITLE
Add manual NuGet workflow for tag validation and publishing

### DIFF
--- a/.github/workflows/nuget-manual.yml
+++ b/.github/workflows/nuget-manual.yml
@@ -1,10 +1,18 @@
-name: Publish NuGet.org (.NET packages)
-run-name: ${{ github.ref_name }}
+name: Validate or publish NuGet.org tag (.NET packages)
+run-name: ${{ inputs.release_tag }}${{ inputs.publish_to_nuget && ' (publish)' || ' (dry-run)' }}
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to publish (for example v2.1.0)
+        required: true
+        type: string
+      publish_to_nuget:
+        description: Push the built packages to NuGet.org after validation
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -13,6 +21,8 @@ jobs:
   build-native:
     name: Build native (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_REF: ${{ format('refs/tags/{0}', inputs.release_tag) }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -70,15 +82,18 @@ jobs:
           path: out/
 
   pack-and-push:
-    name: Pack + publish NuGet.org
+    name: Pack + optional NuGet.org publish
     runs-on: ubuntu-latest
     needs: [build-native]
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_REF: ${{ format('refs/tags/{0}', inputs.release_tag) }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Set up .NET 10
         uses: actions/setup-dotnet@v4
@@ -220,6 +235,7 @@ jobs:
           unzip -l "$pkg" | grep -q "lib/net10.0/DecentDB.EntityFrameworkCore.NodaTime.dll"
 
       - name: Publish to NuGet.org
+        if: ${{ inputs.publish_to_nuget }}
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         shell: bash
@@ -234,3 +250,7 @@ jobs:
             echo "NUGET_API_KEY not set, skipping NuGet.org publish"
             exit 1
           fi
+
+      - name: Confirm dry-run package validation
+        if: ${{ !inputs.publish_to_nuget }}
+        run: echo "Validated and packed release artifacts without publishing to NuGet.org."

--- a/crates/decentdb/src/bin/miri_smoke.rs
+++ b/crates/decentdb/src/bin/miri_smoke.rs
@@ -20,18 +20,16 @@ fn main() -> Result<()> {
     let header = db.read_page(1)?;
     assert_eq!(header.len(), db.config().page_size as usize);
 
-    eprintln!("miri_smoke: commit empty write txn");
-    db.begin_write()?;
-    db.commit()?;
-
     eprintln!("miri_smoke: hold and release snapshot");
     let snapshot = db.hold_snapshot()?;
     assert_eq!(db.storage_info()?.active_readers, 1);
     db.release_snapshot(snapshot)?;
     assert_eq!(db.storage_info()?.active_readers, 0);
 
-    eprintln!("miri_smoke: rollback empty write txn");
+    eprintln!("miri_smoke: begin empty write txn");
     db.begin_write()?;
+
+    eprintln!("miri_smoke: rollback empty write txn");
     db.rollback()?;
 
     eprintln!("miri_smoke: done");

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -17,13 +17,20 @@ or publishing a release from the GitHub UI does not reliably go through that
 same event path, so if a tag is created server-side you may need to use
 `workflow_dispatch` to run the release pipeline manually.
 
-The NuGet workflow in `.github/workflows/nuget.yml` also supports
-`workflow_dispatch`, but it should be started from `main`, not from the tag
-itself, with:
+NuGet package publication stays on the tag-triggered workflow in
+`.github/workflows/nuget.yml`, so the normal publish history remains
+tag-oriented.
+
+For manual recovery or validation of an existing tag, use the separate workflow
+in `.github/workflows/nuget-manual.yml` from `main`, with:
 
 - `release_tag` set to the existing release tag, such as `v2.1.0`
 - `publish_to_nuget` left at `false` for a safe dry run that builds, packs, and
   verifies package contents without publishing
+
+Manual runs use the selected `release_tag` in the workflow run title and stay in
+their own workflow history instead of appearing under the primary tag-publish
+workflow.
 
 Set `publish_to_nuget` to `true` only when you intentionally want that manual
 run to push packages to NuGet.org.


### PR DESCRIPTION
This pull request introduces a new workflow for manual NuGet package validation and publishing, and simplifies the main NuGet publishing workflow to only support tag-based publishing. The changes improve the clarity, safety, and separation of automated versus manual package publishing, and update documentation accordingly.

**Workflows: Separation of Tag-triggered and Manual NuGet Publishing**

* Added a new workflow file, `.github/workflows/nuget-manual.yml`, to support manual validation or publishing of NuGet packages for an existing tag. This workflow allows specifying a `release_tag` and whether to publish or just validate, and includes extensive steps for building, packing, verifying, and optionally publishing packages.
* Removed support for `workflow_dispatch` (manual runs) from the main `.github/workflows/nuget.yml` workflow, making it strictly tag-triggered and simplifying its logic and environment variable handling. [[1]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R2-L17) [[2]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6L26-L27) [[3]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6L46-L47) [[4]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6L87-L98) [[5]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6L240) [[6]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6L255-L258)

**Documentation Updates**

* Updated `docs/development/releases.md` to clarify the new workflow split: normal NuGet publishing is tag-based, while manual validation or recovery uses the new workflow with explicit instructions for usage.