### PR TITLE
Enhance NuGet workflow with manual trigger options and documentation

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,10 +1,26 @@
 name: Publish NuGet.org (.NET packages)
-run-name: ${{ github.ref_name }}
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch'
+    && format('{0} ({1})', inputs.release_tag, inputs.publish_to_nuget && 'publish' || 'dry-run')
+    || github.ref_name
+  }}
 
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to publish (for example v2.1.0)
+        required: true
+        type: string
+      publish_to_nuget:
+        description: Push the built packages to NuGet.org after validation
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -13,6 +29,8 @@ jobs:
   build-native:
     name: Build native (${{ matrix.rid }})
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -70,15 +90,18 @@ jobs:
           path: out/
 
   pack-and-push:
-    name: Pack + publish NuGet.org
+    name: Pack + optional NuGet.org publish
     runs-on: ubuntu-latest
     needs: [build-native]
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_REF }}
 
       - name: Set up .NET 10
         uses: actions/setup-dotnet@v4
@@ -220,6 +243,7 @@ jobs:
           unzip -l "$pkg" | grep -q "lib/net10.0/DecentDB.EntityFrameworkCore.NodaTime.dll"
 
       - name: Publish to NuGet.org
+        if: ${{ github.event_name == 'push' || inputs.publish_to_nuget == true }}
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         shell: bash
@@ -234,3 +258,7 @@ jobs:
             echo "NUGET_API_KEY not set, skipping NuGet.org publish"
             exit 1
           fi
+
+      - name: Confirm dry-run package validation
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_to_nuget != true }}
+        run: echo "Validated and packed release artifacts without publishing to NuGet.org."

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -17,23 +17,24 @@ or publishing a release from the GitHub UI does not reliably go through that
 same event path, so if a tag is created server-side you may need to use
 `workflow_dispatch` to run the release pipeline manually.
 
-NuGet package publication stays on the tag-triggered workflow in
-`.github/workflows/nuget.yml`, so the normal publish history remains
-tag-oriented.
+The primary NuGet workflow in `.github/workflows/nuget.yml` supports both the
+normal tag-triggered publish path and a manual `workflow_dispatch` path.
 
-For manual recovery or validation of an existing tag, use the separate workflow
-in `.github/workflows/nuget-manual.yml` from `main`, with:
+For manual recovery or validation of an existing tag, start `nuget.yml` from
+`main`, with:
 
 - `release_tag` set to the existing release tag, such as `v2.1.0`
 - `publish_to_nuget` left at `false` for a safe dry run that builds, packs, and
   verifies package contents without publishing
 
-Manual runs use the selected `release_tag` in the workflow run title and stay in
-their own workflow history instead of appearing under the primary tag-publish
-workflow.
+Manual runs use the selected `release_tag` in the workflow run title.
 
 Set `publish_to_nuget` to `true` only when you intentionally want that manual
 run to push packages to NuGet.org.
+
+If you want manual recovery runs kept in a separate workflow list, the optional
+`.github/workflows/nuget-manual.yml` workflow provides the same manual path in a
+dedicated workflow entry.
 
 ## CI lanes
 


### PR DESCRIPTION
This pull request updates the NuGet publishing workflow to support both tag-triggered and manual (`workflow_dispatch`) releases from the GitHub UI, making it safer and easier to validate or recover releases. The workflow now allows dry-run validations or actual publishing for any existing release tag, and the documentation is updated to reflect these changes.

**Workflow improvements:**

* Added support for manual `workflow_dispatch` runs with `release_tag` and `publish_to_nuget` inputs, enabling safe dry-run validations or explicit publish actions for existing tags. The workflow run title now reflects the selected release tag and publish mode.
* Both build and pack jobs now check out the correct tag based on the trigger (push or manual), ensuring the right code is used for packaging. [[1]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R32-R33) [[2]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R52-R53) [[3]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6L73-R104)
* The publish step now only pushes to NuGet.org if triggered by a tag push or if `publish_to_nuget` is explicitly set to true; otherwise, it performs a dry run and confirms validation without publishing. [[1]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R246) [[2]](diffhunk://#diff-bd6633be65e4d24ae2dd48955f22acf723749bda3921fcd1877ea0b8192ae0b6R261-R264)

**Documentation updates:**

* Updated release documentation to describe the new manual workflow path, clarify usage of `release_tag` and `publish_to_nuget`, and explain the difference between primary and optional manual workflows.… documentation