### PR TITLE
Add Dart-native asset packaging for GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,21 +139,25 @@ jobs:
             release_suffix: Linux-x64
             java_suffix: Linux
             artifact_name: linux-x64
+            dart_lib_name: libdecentdb.so
           - label: Linux arm64
             runner: ubuntu-24.04-arm
             release_suffix: Linux-arm64
             java_suffix: Linux-arm64
             artifact_name: linux-arm64
+            dart_lib_name: libdecentdb.so
           - label: Windows x64
             runner: windows-latest
             release_suffix: Windows-x64
             java_suffix: Windows
             artifact_name: windows-x64
+            dart_lib_name: decentdb.dll
           - label: macOS arm64
             runner: macos-latest
             release_suffix: macOS-arm64
             java_suffix: macOS
             artifact_name: macos-arm64
+            dart_lib_name: libdecentdb.dylib
 
     steps:
       - name: Checkout
@@ -251,6 +255,17 @@ jobs:
           OUT="decentdb-${TAG}-${{ matrix.release_suffix }}.tar.gz"
           tar -C dist -czf "$OUT" .
 
+      - name: Package Dart-native asset (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          mkdir -p dart-dist
+          cp -v "dist/${{ matrix.dart_lib_name }}" "dart-dist/${{ matrix.dart_lib_name }}"
+          OUT="decentdb-dart-native-${TAG}-${{ matrix.release_suffix }}.tar.gz"
+          tar -C dart-dist -czf "$OUT" "${{ matrix.dart_lib_name }}"
+
       - name: Package DBeaver plugin (Linux/macOS)
         if: runner.os != 'Windows'
         shell: bash
@@ -267,6 +282,18 @@ jobs:
           $tag = "$env:GITHUB_REF_NAME"
           $out = "decentdb-$tag-${{ matrix.release_suffix }}.zip"
           Compress-Archive -Path dist\* -DestinationPath $out -Force
+
+      - name: Package Dart-native asset (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $tag = "$env:GITHUB_REF_NAME"
+          $dartDist = "dart-dist"
+          New-Item -ItemType Directory -Force $dartDist | Out-Null
+          Copy-Item -Force "dist\\${{ matrix.dart_lib_name }}" "$dartDist\\${{ matrix.dart_lib_name }}"
+          $out = "decentdb-dart-native-$tag-${{ matrix.release_suffix }}.zip"
+          if (Test-Path $out) { Remove-Item -Force $out }
+          Compress-Archive -Path "$dartDist\\*" -DestinationPath $out -Force
 
       - name: Package DBeaver plugin (Windows)
         if: runner.os == 'Windows'
@@ -287,6 +314,8 @@ jobs:
             path: |
               decentdb-${{ github.ref_name }}-${{ matrix.release_suffix }}.tar.gz
               decentdb-${{ github.ref_name }}-${{ matrix.release_suffix }}.zip
+              decentdb-dart-native-${{ github.ref_name }}-${{ matrix.release_suffix }}.tar.gz
+              decentdb-dart-native-${{ github.ref_name }}-${{ matrix.release_suffix }}.zip
               decentdb-jdbc-${{ github.ref_name }}-${{ matrix.java_suffix }}.jar
               decentdb-dbeaver-${{ github.ref_name }}-${{ matrix.java_suffix }}.zip
 
@@ -312,6 +341,10 @@ jobs:
             artifacts/**/decentdb-${{ github.ref_name }}-Linux-arm64.tar.gz
             artifacts/**/decentdb-${{ github.ref_name }}-macOS-arm64.tar.gz
             artifacts/**/decentdb-${{ github.ref_name }}-Windows-x64.zip
+            artifacts/**/decentdb-dart-native-${{ github.ref_name }}-Linux-x64.tar.gz
+            artifacts/**/decentdb-dart-native-${{ github.ref_name }}-Linux-arm64.tar.gz
+            artifacts/**/decentdb-dart-native-${{ github.ref_name }}-macOS-arm64.tar.gz
+            artifacts/**/decentdb-dart-native-${{ github.ref_name }}-Windows-x64.zip
             artifacts/**/decentdb-jdbc-${{ github.ref_name }}-Linux.jar
             artifacts/**/decentdb-jdbc-${{ github.ref_name }}-Linux-arm64.jar
             artifacts/**/decentdb-jdbc-${{ github.ref_name }}-macOS.jar

--- a/bindings/dart/README.md
+++ b/bindings/dart/README.md
@@ -51,6 +51,18 @@ The Rust `cdylib` is emitted to:
 - macOS: `target/debug/libdecentdb.dylib`
 - Windows: `target/debug/decentdb.dll`
 
+For Flutter/Dart desktop packaging, GitHub Releases also publish small
+platform-native archives that contain just the FFI library:
+
+- `decentdb-dart-native-<tag>-Linux-x64.tar.gz`
+- `decentdb-dart-native-<tag>-Linux-arm64.tar.gz`
+- `decentdb-dart-native-<tag>-macOS-arm64.tar.gz`
+- `decentdb-dart-native-<tag>-Windows-x64.zip`
+
+Each archive extracts to the platform-native library file
+(`libdecentdb.so`, `libdecentdb.dylib`, or `decentdb.dll`) so desktop apps can
+bundle it directly.
+
 You can also use the helper script:
 
 ```bash

--- a/docs/api/dart.md
+++ b/docs/api/dart.md
@@ -19,6 +19,18 @@ The Dart package loads the built shared library from `DECENTDB_NATIVE_LIB` or an
 - macOS: `target/debug/libdecentdb.dylib`
 - Windows: `target/debug/decentdb.dll`
 
+For Flutter/Dart desktop packaging, GitHub Releases also publish small
+platform-native archives that contain just the FFI library:
+
+- `decentdb-dart-native-<tag>-Linux-x64.tar.gz`
+- `decentdb-dart-native-<tag>-Linux-arm64.tar.gz`
+- `decentdb-dart-native-<tag>-macOS-arm64.tar.gz`
+- `decentdb-dart-native-<tag>-Windows-x64.zip`
+
+Each archive extracts to the platform-native library file
+(`libdecentdb.so`, `libdecentdb.dylib`, or `decentdb.dll`) so desktop apps can
+bundle it directly.
+
 ## Quick start
 
 ```dart

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,11 +6,22 @@ GitHub Releases publish native archives for:
 
 - `decentdb-<tag>-Linux-x64.tar.gz`
 - `decentdb-<tag>-Linux-arm64.tar.gz`
-- `decentdb-<tag>-macOS-x64.tar.gz`
+- `decentdb-<tag>-macOS-arm64.tar.gz`
 - `decentdb-<tag>-Windows-x64.zip`
 
-Each archive contains the CLI plus the native shared library used by bindings.
-Extract the archive and place `decentdb` (or `decentdb.exe`) on your `PATH`.
+For Dart/Flutter desktop consumers, Releases also publish native-library-only
+archives:
+
+- `decentdb-dart-native-<tag>-Linux-x64.tar.gz`
+- `decentdb-dart-native-<tag>-Linux-arm64.tar.gz`
+- `decentdb-dart-native-<tag>-macOS-arm64.tar.gz`
+- `decentdb-dart-native-<tag>-Windows-x64.zip`
+
+The main `decentdb-<tag>-...` archives contain the CLI plus the native shared
+library used by bindings. The `decentdb-dart-native-<tag>-...` archives contain
+only the shared library for Flutter/Dart desktop packaging. Extract the archive
+that matches your use case and place `decentdb` (or `decentdb.exe`) on your
+`PATH` when you install the full CLI archive.
 
 ## Build from source
 


### PR DESCRIPTION
This pull request adds support for publishing platform-native Dart FFI library archives as part of the GitHub release process and updates documentation to reflect these new artifacts. These changes make it easier for Dart and Flutter desktop apps to bundle only the native shared library without the full CLI.

**Release workflow updates:**

* Added a `dart_lib_name` matrix entry for each platform in `.github/workflows/release.yml` to specify the correct native library filename (`.so`, `.dll`, `.dylib`).
* Added steps to package and upload Dart-native-only archives (`decentdb-dart-native-<tag>-<platform>.<ext>`) for Linux, macOS, and Windows. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R258-R268) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R286-R297) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R317-R318) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R344-R347)

**Documentation updates:**

* Updated `bindings/dart/README.md`, `docs/api/dart.md`, and `docs/getting-started/installation.md` to explain the new Dart-native archives, their naming, and usage for Flutter/Dart desktop packaging. [[1]](diffhunk://#diff-978e234ec1009dd8002098a705e2170e1ed2d9c2ee6782fe39475b0db6ac614aR54-R65) [[2]](diffhunk://#diff-2a82f611eada988763f571a0b7bd6f5f5135ff6148edb2503cd6c2a3796b3de2R22-R33) [[3]](diffhunk://#diff-6828264893dbf2a68733af90bf5996b5b8afec681e5d6f216edca2ec9c8d1fa5L9-R24)