### PR TITLE
test(bindings): update java ffm usage and fix node header resolution

### DIFF
--- a/tests/bindings/java/Smoke.java
+++ b/tests/bindings/java/Smoke.java
@@ -64,13 +64,13 @@ public final class Smoke {
                 FunctionDescriptor.of(JAVA_INT, ADDRESS));
 
             MemorySegment dbSlot = arena.allocate(ADDRESS);
-            check((int) open.invokeExact(arena.allocateFrom(":memory:"), dbSlot), "open_or_create", lastError);
+            check((int) open.invokeExact(arena.allocateUtf8String(":memory:"), dbSlot), "open_or_create", lastError);
             MemorySegment db = dbSlot.get(ADDRESS, 0);
 
             MemorySegment resultSlot = arena.allocate(ADDRESS);
             check((int) execute.invokeExact(
                 db,
-                arena.allocateFrom("CREATE TABLE smoke (id INT64 PRIMARY KEY, name TEXT)"),
+                arena.allocateUtf8String("CREATE TABLE smoke (id INT64 PRIMARY KEY, name TEXT)"),
                 MemorySegment.NULL,
                 0L,
                 resultSlot
@@ -79,7 +79,7 @@ public final class Smoke {
 
             check((int) execute.invokeExact(
                 db,
-                arena.allocateFrom("INSERT INTO smoke (id, name) VALUES (1, 'java-smoke')"),
+                arena.allocateUtf8String("INSERT INTO smoke (id, name) VALUES (1, 'java-smoke')"),
                 MemorySegment.NULL,
                 0L,
                 resultSlot
@@ -88,7 +88,7 @@ public final class Smoke {
 
             check((int) executeQueued.invokeExact(
                 db,
-                arena.allocateFrom("INSERT INTO smoke (id, name) VALUES (2, 'java-queued')"),
+                arena.allocateUtf8String("INSERT INTO smoke (id, name) VALUES (2, 'java-queued')"),
                 MemorySegment.NULL,
                 0L,
                 DDB_WRITE_QUEUE_TIMEOUT_DEFAULT,
@@ -104,13 +104,13 @@ public final class Smoke {
             MemorySegment watchSlot = arena.allocate(ADDRESS);
             check((int) watchQuery.invokeExact(
                 db,
-                arena.allocateFrom("{\"sql\":\"SELECT id, name FROM smoke ORDER BY id\"}"),
+                arena.allocateUtf8String("{\"sql\":\"SELECT id, name FROM smoke ORDER BY id\"}"),
                 watchSlot
             ), "watch query", lastError);
             MemorySegment watch = watchSlot.get(ADDRESS, 0);
             MemorySegment eventSlot = arena.allocate(ADDRESS);
             check((int) watchNext.invokeExact(watch, 1000, eventSlot), "watch initial", lastError);
-            String initial = eventSlot.get(ADDRESS, 0).reinterpret(Long.MAX_VALUE).getString(0);
+            String initial = eventSlot.get(ADDRESS, 0).reinterpret(Long.MAX_VALUE).getUtf8String(0);
             if (!initial.contains("\"type\":\"initial\"")) {
                 throw new IllegalStateException("unexpected initial watch event: " + initial);
             }
@@ -118,14 +118,14 @@ public final class Smoke {
 
             check((int) execute.invokeExact(
                 db,
-                arena.allocateFrom("INSERT INTO smoke (id, name) VALUES (3, 'java-watch')"),
+                arena.allocateUtf8String("INSERT INTO smoke (id, name) VALUES (3, 'java-watch')"),
                 MemorySegment.NULL,
                 0L,
                 resultSlot
             ), "watch insert", lastError);
             check((int) resultFree.invokeExact(resultSlot), "free watch insert", lastError);
             check((int) watchNext.invokeExact(watch, 1000, eventSlot), "watch invalidate", lastError);
-            String invalidate = eventSlot.get(ADDRESS, 0).reinterpret(Long.MAX_VALUE).getString(0);
+            String invalidate = eventSlot.get(ADDRESS, 0).reinterpret(Long.MAX_VALUE).getUtf8String(0);
             if (!invalidate.contains("\"type\":\"invalidate\"") || !invalidate.contains("\"smoke\"")) {
                 throw new IllegalStateException("unexpected invalidate watch event: " + invalidate);
             }
@@ -138,7 +138,7 @@ public final class Smoke {
 
             check((int) execute.invokeExact(
                 db,
-                arena.allocateFrom("SELECT id, name FROM smoke"),
+                arena.allocateUtf8String("SELECT id, name FROM smoke"),
                 MemorySegment.NULL,
                 0L,
                 resultSlot
@@ -153,7 +153,7 @@ public final class Smoke {
 
             int status = (int) execute.invokeExact(
                 db,
-                arena.allocateFrom("SELECT * FROM nope"),
+                arena.allocateUtf8String("SELECT * FROM nope"),
                 MemorySegment.NULL,
                 0L,
                 resultSlot
@@ -178,7 +178,7 @@ public final class Smoke {
 
     private static String errorString(MethodHandle lastError) throws Throwable {
         MemorySegment segment = (MemorySegment) lastError.invokeExact();
-        return segment.equals(MemorySegment.NULL) ? "" : segment.reinterpret(Long.MAX_VALUE).getString(0);
+        return segment.equals(MemorySegment.NULL) ? "" : segment.reinterpret(Long.MAX_VALUE).getUtf8String(0);
     }
 
     private static Path locateLibrary(Path root) throws IOException {

--- a/tests/bindings/node/build.sh
+++ b/tests/bindings/node/build.sh
@@ -12,12 +12,14 @@ elif [ -d "$node_prefix/include" ] && [ -f "$node_prefix/include/node_api.h" ]; 
 elif [ -n "${nodedir:-}" ] && [ -d "$nodedir/include/node" ]; then
   node_include="$nodedir/include/node"
 else
-  # Add node-api header as npm package if it doesn't exist
-  # (sometimes github actions node doesn't include headers in prefix)
+  # Add Node-API headers as a local npm package if the Node distribution does
+  # not ship headers in its prefix. Keep this under .tmp so validation never
+  # requires global npm write permissions.
   echo "Fetching node-addon-api headers..."
-  npm install -g node-api-headers || true
-  node_headers_dir=$(npm root -g)/node-api-headers/include
-  if [ -d "$node_headers_dir" ]; then
+  headers_prefix="${NODE_API_HEADERS_PREFIX:-$root/.tmp/node-api-headers}"
+  npm install --prefix "$headers_prefix" --no-audit --no-fund node-api-headers
+  node_headers_dir="$headers_prefix/node_modules/node-api-headers/include"
+  if [ -f "$node_headers_dir/node_api.h" ]; then
       node_include="$node_headers_dir"
   else
       # fallback / debug


### PR DESCRIPTION
Update Java smoke test to use explicit UTF-8 memory allocation and string retrieval for compatibility with modern FFM APIs. Refactor the Node-API build script to install headers into a local temporary directory instead of globally, preventing permission errors in restricted environments.