### PR TITLE
refactor(benchmarks): update python driver prepared statement handling

### DIFF
--- a/benchmarks/python_embedded_compare/drivers/duckdb_driver.py
+++ b/benchmarks/python_embedded_compare/drivers/duckdb_driver.py
@@ -21,7 +21,7 @@ class DuckDBDriver(DatabaseDriver):
         super().__init__(config)
         self.db_path = config.get("database_path", "duckdb.db")
         self._cursor = None
-        self._prepared_stmts: Dict[str, duckdb.Statement] = {}
+        self._prepared_stmts: Dict[str, Any] = {}
 
     @property
     def name(self) -> str:
@@ -46,6 +46,11 @@ class DuckDBDriver(DatabaseDriver):
                 self.connection.execute("CHECKPOINT")
             except:
                 pass
+            for cursor in self._prepared_stmts.values():
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
             self.connection.close()
             self.connection = None
             self._cursor = None
@@ -98,19 +103,22 @@ class DuckDBDriver(DatabaseDriver):
     def rollback(self):
         self.connection.execute("ROLLBACK")
 
-    def prepare_statement(self, sql: str) -> duckdb.Statement:
-        stmt = self.connection.prepare(sql)
-        self._prepared_stmts[sql] = stmt
-        return stmt
+    def prepare_statement(self, sql: str):
+        cursor = self._prepared_stmts.get(sql)
+        if cursor is None:
+            cursor = self.connection.cursor()
+            self._prepared_stmts[sql] = cursor
+        return sql, cursor
 
     def execute_prepared(
-        self, handle: duckdb.Statement, params: Optional[Tuple] = None
+        self, handle: Any, params: Optional[Tuple] = None
     ) -> Any:
+        sql, cursor = handle
         if params:
-            result = handle.execute(params)
+            cursor.execute(sql, params)
         else:
-            result = handle.execute()
-        return result.fetchall()
+            cursor.execute(sql)
+        return cursor.fetchall() if cursor.description else cursor.rowcount
 
     def get_engine_metadata(self) -> EngineMetadata:
         version = duckdb.__version__

--- a/benchmarks/python_embedded_compare/drivers/jdbc_driver.py
+++ b/benchmarks/python_embedded_compare/drivers/jdbc_driver.py
@@ -167,6 +167,12 @@ class JDBCDriver(DatabaseDriver):
 
     def disconnect(self):
         if self.connection:
+            for cursor in self._prepared_stmts.values():
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+            self._prepared_stmts.clear()
             try:
                 self.connection.close()
             except:
@@ -235,20 +241,22 @@ class JDBCDriver(DatabaseDriver):
 
     def prepare_statement(self, sql: str):
         sql = self._adapt_sql(sql)
-        cursor = self.connection.cursor()
-        cursor.prepare(sql)
-        self._prepared_stmts[sql] = cursor
-        return cursor
+        cursor = self._prepared_stmts.get(sql)
+        if cursor is None:
+            cursor = self.connection.cursor()
+            self._prepared_stmts[sql] = cursor
+        return sql, cursor
 
     def execute_prepared(self, handle, params: Optional[Tuple] = None) -> Any:
+        sql, cursor = handle
         if params:
-            handle.execute(params)
+            cursor.execute(sql, params)
         else:
-            handle.execute()
+            cursor.execute(sql)
 
-        if handle.description:
-            return handle.fetchall()
-        return handle.rowcount
+        if cursor.description:
+            return cursor.fetchall()
+        return cursor.rowcount
 
     def get_engine_metadata(self) -> EngineMetadata:
         # Try to get version from the engine

--- a/benchmarks/python_embedded_compare/tests/test_smoke.py
+++ b/benchmarks/python_embedded_compare/tests/test_smoke.py
@@ -152,6 +152,22 @@ class TestSmokeDuckDB:
 
         driver.disconnect()
 
+    @pytest.mark.skipif(not DUCKDB_AVAILABLE, reason="DuckDB not installed")
+    def test_duckdb_prepared_statement_fallback(self, temp_db_path):
+        """DuckDB prepared benchmark path should not require connection.prepare."""
+        driver = DuckDBDriver({"database_path": temp_db_path})
+        assert driver.connect()
+
+        driver.execute_update("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+        driver.execute_update("INSERT INTO test VALUES (?, ?)", (1, "duckdb"))
+
+        handle = driver.prepare_statement("SELECT value FROM test WHERE id = ?")
+        result = driver.execute_prepared(handle, (1,))
+
+        assert result == [("duckdb",)]
+
+        driver.disconnect()
+
 
 class TestWorkloads:
     """Test workload implementations."""
@@ -262,6 +278,50 @@ class TestJdbcDriverConfig:
         )
 
         assert driver.jar_paths == [str(jar_path.resolve())]
+
+    def test_jdbc_prepared_statement_uses_dbapi_cursor_execute(self):
+        """JDBC prepared benchmark path should not require JayDeBeApi cursor.prepare."""
+
+        class FakeCursor:
+            description = [("id",)]
+            rowcount = 1
+
+            def __init__(self):
+                self.calls = []
+                self.closed = False
+
+            def execute(self, sql, params=None):
+                self.calls.append((sql, params))
+
+            def fetchall(self):
+                return [(1,)]
+
+            def close(self):
+                self.closed = True
+
+        class FakeConnection:
+            def __init__(self):
+                self.cursors = []
+
+            def cursor(self):
+                cursor = FakeCursor()
+                self.cursors.append(cursor)
+                return cursor
+
+        driver = JDBCDriver({"engine": "h2"})
+        fake_connection = FakeConnection()
+        driver.connection = fake_connection
+
+        handle = driver.prepare_statement("SELECT id FROM bench WHERE id = ?")
+        result = driver.execute_prepared(handle, (7,))
+        second_handle = driver.prepare_statement("SELECT id FROM bench WHERE id = ?")
+
+        assert result == [(1,)]
+        assert handle[1] is second_handle[1]
+        assert len(fake_connection.cursors) == 1
+        assert fake_connection.cursors[0].calls == [
+            ("SELECT id FROM bench WHERE id = ?", (7,))
+        ]
 
     @_skip_no_firebird
     def test_firebird_driver_adds_native_support_jars(self):


### PR DESCRIPTION
Refactor the DuckDB and JDBC drivers in the python embedded compare benchmarks to use a more robust prepared statement mechanism.

Changes include:
- Updating `prepare_statement` to return a tuple of (sql, cursor) instead of a driver-specific statement object.
- Modifying `execute_prepared` to utilize the returned cursor and SQL string, improving compatibility with standard DB-API 2.0 patterns.
- Implementing proper resource cleanup for prepared cursors during driver disconnection.
- Adding smoke tests to verify the new prepared statement logic for both DuckDB and JDBC drivers.