### PR TITLE
fix(benchmarks): improve derby sql adaptation and update asset list

### DIFF
--- a/.github/workflows/benchmark-assets.yml
+++ b/.github/workflows/benchmark-assets.yml
@@ -340,9 +340,10 @@ jobs:
           from pathlib import Path
 
           expected = {
-              "decentdb_default_durable",
+              "decentdb_balanced_durable",
+              "decentdb_low_memory_durable",
               "decentdb_tuned_durable",
-              "duckdb",
+              "duckdb_engine_default",
               "sqlite",
               "H2",
               "HSQLDB",

--- a/benchmarks/python_embedded_compare/drivers/jdbc_driver.py
+++ b/benchmarks/python_embedded_compare/drivers/jdbc_driver.py
@@ -113,6 +113,7 @@ class JDBCDriver(DatabaseDriver):
         if self.engine == "derby":
             adapted = adapted.replace(" ORDER BY created_at LIMIT ?", " ORDER BY created_at FETCH FIRST ? ROWS ONLY")
             adapted = adapted.replace(" ORDER BY o.created_at LIMIT ?", " ORDER BY o.created_at FETCH FIRST ? ROWS ONLY")
+            adapted = adapted.replace(" LIMIT ?", " FETCH FIRST ? ROWS ONLY")
 
         return adapted
 

--- a/benchmarks/python_embedded_compare/tests/test_smoke.py
+++ b/benchmarks/python_embedded_compare/tests/test_smoke.py
@@ -279,6 +279,19 @@ class TestJdbcDriverConfig:
 
         assert driver.jar_paths == [str(jar_path.resolve())]
 
+    def test_derby_adapts_parameterized_limit(self):
+        """Derby should accept Workload C materialization limit syntax."""
+        driver = JDBCDriver({"engine": "derby"})
+
+        adapted = driver._adapt_sql(
+            "SELECT id, val, f FROM bench WHERE id >= ? LIMIT ?"
+        )
+
+        assert (
+            adapted
+            == "SELECT id, val, f FROM bench WHERE id >= ? FETCH FIRST ? ROWS ONLY"
+        )
+
     def test_jdbc_prepared_statement_uses_dbapi_cursor_execute(self):
         """JDBC prepared benchmark path should not require JayDeBeApi cursor.prepare."""
 


### PR DESCRIPTION
Refine the JDBC driver's SQL adaptation logic to ensure compatibility with Derby's syntax for parameterized LIMIT clauses and update the benchmark asset workflow to reflect changes in engine naming and configuration profiles.

Changes include:
- Update `JDBCDriver` to replace `LIMIT ?` with `FETCH FIRST ? ROWS ONLY` for Derby engines.
- Add a smoke test to verify Derby's SQL adaptation for parameterized limits.
- Update `.github/workflows/benchmark-assets.yml` to include new engine profiles (`decentdb_balanced_durable`, `decentdb_low_memory_durable`) and correct the DuckDB engine name.