### PR TITLE
ci(benchmarks): add narrative validation and rust-baseline cross-check

### DIFF
--- a/.github/workflows/benchmark-assets.yml
+++ b/.github/workflows/benchmark-assets.yml
@@ -134,6 +134,26 @@ jobs:
           set -euo pipefail
           cargo build -p decentdb --release --quiet
 
+      - name: Generate rust-baseline release cross-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/benchmark-assets/rust-baseline-current
+          cargo run \
+            --manifest-path benchmarks/rust-baseline/Cargo.toml \
+            --bin rust-baseline \
+            --release \
+            --quiet \
+            -- \
+            --scale full \
+            --out-dir "$GITHUB_WORKSPACE/.tmp/benchmark-assets/rust-baseline-current" \
+            --db-path "$GITHUB_WORKSPACE/.tmp/benchmark-assets/rust-baseline-current/run-rust-full.ddb"
+          python scripts/compare_rust_baseline.py \
+            --current-dir .tmp/benchmark-assets/rust-baseline-current \
+            --scale full \
+            > .tmp/benchmark-assets/rust-baseline-compare.txt
+          cat .tmp/benchmark-assets/rust-baseline-compare.txt
+
       - name: Generate native benchmark summary
         shell: bash
         run: |
@@ -360,6 +380,15 @@ jobs:
               sys.exit(1)
           PY
 
+      - name: Validate release benchmark narrative
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/validate_release_benchmark_narrative.py \
+            --summary data/bench_summary.json \
+            --rust-baseline-current-dir .tmp/benchmark-assets/rust-baseline-current \
+            --report .tmp/benchmark-assets/benchmark-narrative.txt
+
       - name: Generate README benchmark assets
         shell: bash
         run: |
@@ -391,6 +420,9 @@ jobs:
             data/bench_summary.json
             docs/assets/benchmarks/python-embedded-compare
             docs/user-guide/benchmarks.md
+            .tmp/benchmark-assets/benchmark-narrative.txt
+            .tmp/benchmark-assets/rust-baseline-compare.txt
+            .tmp/benchmark-assets/rust-baseline-current
             .tmp/benchmark-assets/workload_a
             .tmp/benchmark-assets/workload_c
             .tmp/benchmark-assets/root-readme-results.json

--- a/README.md
+++ b/README.md
@@ -99,10 +99,19 @@ It preserves a **one writer** and **many concurrent readers** concurrency model 
 - The README chart assets are rendered from `data/bench_summary.json` by `python scripts/make_readme_chart.py` and `python scripts/visualize_alternative.py`.
 - Checked-in chart assets use the accepted release benchmark snapshot. Local diagnostic benchmark runs should not replace `data/bench_summary.json` unless they were collected in the release benchmark lane.
 - Native runs now keep DecentDB rows separate by profile:
-  - `decentdb_balanced_durable` — current balanced durable default config (`wal_sync_full`, 16 MB cache)
+  - `decentdb_balanced_durable` — current balanced durable config (`wal_sync_full`, 16 MB cache)
   - `decentdb_low_memory_durable` — constrained-host durable config (`wal_sync_full`, 4 MB cache)
   - `decentdb_tuned_durable` — durability-preserving tuned config (`wal_sync_full`, 64 MB cache, `retain_paged_row_sources_after_commit`)
   - `decentdb_default_durable` — legacy release-snapshot key for historical 4 MB default rows
+- Native DecentDB chart rows run with `process_coordination=single_process_unsafe`
+  because this chart is a single-process embedded-engine comparison. Cross-process
+  coordination is validated separately and should not be inferred from these
+  hot-path bars.
+- The benchmark asset workflow also runs the raw `rust-baseline` full-scale
+  cross-check and validates the merged chart summary before publishing. If the
+  README chart would show a severe tuned-profile drop while the raw engine
+  baseline remains healthy, the workflow fails instead of committing confusing
+  assets.
 - SQLite results are reported as `sqlite_wal_full` (WAL+FULL sync); relaxed durability variants can be added as separate profiles when collected.
 - Chart values are **normalized vs SQLite** (baseline = 1.0), and the charted metric set is the full native set collected in the benchmark JSON:
   - `read_p95_ms`, `join_p95_ms`, `range_scan_p95_ms`, `aggregate_p95_ms`, `concurrent_read_p95_ms`, `commit_p95_ms`, `insert_rows_per_sec`.

--- a/crates/decentdb/benches/embedded_compare.rs
+++ b/crates/decentdb/benches/embedded_compare.rs
@@ -166,6 +166,7 @@ fn decentdb_config_for_profile(profile: DecentDbProfile, temp_dir: PathBuf) -> d
         DecentDbProfile::Tuned => decentdb::DbConfig::tuned_durable(),
     };
     config.temp_dir = temp_dir;
+    config.process_coordination = decentdb::ProcessCoordinationMode::SingleProcessUnsafe;
     config
 }
 
@@ -1198,28 +1199,28 @@ fn main() {
     summary.metadata.insert(
         "decentdb_profile_balanced".to_string(),
         format!(
-            "{}:wal_sync_full cache_size_mb={}",
+            "{}:wal_sync_full cache_size_mb={} process_coordination=single_process_unsafe",
             DECENTDB_BALANCED_DURABLE_PROFILE, DECENTDB_BALANCED_CACHE_MB
         ),
     );
     summary.metadata.insert(
         "decentdb_profile_default".to_string(),
         format!(
-            "{}:wal_sync_full cache_size_mb={}",
+            "{}:wal_sync_full cache_size_mb={} process_coordination=single_process_unsafe",
             DECENTDB_BALANCED_DURABLE_PROFILE, DECENTDB_BALANCED_CACHE_MB
         ),
     );
     summary.metadata.insert(
         "decentdb_profile_low_memory".to_string(),
         format!(
-            "{}:wal_sync_full cache_size_mb={}",
+            "{}:wal_sync_full cache_size_mb={} process_coordination=single_process_unsafe",
             DECENTDB_LOW_MEMORY_DURABLE_PROFILE, DECENTDB_LOW_MEMORY_CACHE_MB
         ),
     );
     summary.metadata.insert(
         "decentdb_profile_tuned".to_string(),
         format!(
-            "{}:wal_sync_full cache_size_mb={} retain_paged_row_sources_after_commit=true paged_row_storage=false wal_autocheckpoint=0",
+            "{}:wal_sync_full cache_size_mb={} retain_paged_row_sources_after_commit=true paged_row_storage=false wal_autocheckpoint=0 process_coordination=single_process_unsafe",
             DECENTDB_TUNED_DURABLE_PROFILE, DECENTDB_TUNED_CACHE_MB
         ),
     );
@@ -1239,6 +1240,15 @@ fn main() {
     summary.metadata.insert(
         "decentdb_durability".to_string(),
         "wal_sync_full".to_string(),
+    );
+    summary.metadata.insert(
+        "decentdb_process_coordination".to_string(),
+        "single_process_unsafe".to_string(),
+    );
+    summary.metadata.insert(
+        "process_coordination_note".to_string(),
+        "native cross-engine benchmarks are single-process comparisons; cross-process coordination overhead is measured separately"
+            .to_string(),
     );
     summary
         .metadata

--- a/design/BENCHMARKING_GUIDE.md
+++ b/design/BENCHMARKING_GUIDE.md
@@ -121,6 +121,17 @@ The native run writes `data/bench_summary.json`. The helper script
 `benchmarks/python_embedded_compare/out/results_merged.json` before the README
 chart renderers consume the combined summary.
 
+The README native comparison is intentionally a single-process embedded-engine
+benchmark. DecentDB rows set `process_coordination=single_process_unsafe` while
+preserving `WalSyncMode::Full`; cross-process coordination correctness and
+diagnostic overhead are validated outside these release chart bars.
+
+Release asset refreshes also run the raw `benchmarks/rust-baseline` full-scale
+cross-check and `scripts/validate_release_benchmark_narrative.py`. The guard
+prevents publishing a README chart whose tuned durable row communicates a severe
+SQLite-relative drop while the raw-engine baseline tells a materially different
+story.
+
 ```bash
 python scripts/aggregate_benchmarks.py \
   --native-summary data/bench_summary.json \

--- a/design/WIN_DEFAULT_FAST_PERFORMANCE_STORAGE_EFFICIENCY_SPEC.md
+++ b/design/WIN_DEFAULT_FAST_PERFORMANCE_STORAGE_EFFICIENCY_SPEC.md
@@ -281,6 +281,19 @@ Release performance assets must keep at least these profiles distinct:
 Profile names must appear in JSON metadata and generated release charts. Tuned
 results must never replace default results in release-facing assets.
 
+Native cross-engine chart runs are single-process embedded comparisons. They
+may set `process_coordination=single_process_unsafe` only when the metadata and
+README methodology state that scope explicitly; cross-process coordination must
+remain covered by separate correctness and overhead validation.
+
+The release asset workflow must include a raw rust-baseline cross-check and
+fail before publishing if `data/bench_summary.json` would create a materially
+conflicting benchmark narrative. The current guard is
+`scripts/validate_release_benchmark_narrative.py`, which verifies profile
+metadata and requires the tuned durable row to stay competitive against SQLite
+on the release chart metric set unless a regression is explicitly accepted and
+documented.
+
 Release assets must describe competitor durability settings precisely enough
 that readers can compare latency and safety together. For DuckDB, the metadata
 must state the engine-default durability mode used by the benchmark and any

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -137,6 +137,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the native release benchmark lane so DecentDB README chart profiles
+  explicitly run as single-process embedded comparisons with
+  `process_coordination=single_process_unsafe`, while keeping durable
+  `WalSyncMode::Full` and documenting that cross-process coordination is
+  validated separately.
+- Added a release benchmark narrative guard to the benchmark-assets workflow:
+  it now runs the raw rust-baseline full-scale cross-check, uploads the compare
+  report, and fails before publishing README chart assets if the tuned durable
+  chart row and raw-engine baseline tell conflicting performance stories.
 - Fixed legacy database migrations to seed the v13 coordination identity for
   all upgraded source formats and to keep copied WAL header-page frames aligned
   with the migrated main header identity.

--- a/scripts/validate_release_benchmark_narrative.py
+++ b/scripts/validate_release_benchmark_narrative.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Validate that release benchmark assets tell one coherent performance story."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+METRICS = [
+    ("read_p95_ms", "Point read p95", "lower"),
+    ("join_p95_ms", "Join p95", "lower"),
+    ("range_scan_p95_ms", "Range scan p95", "lower"),
+    ("aggregate_p95_ms", "Aggregate p95", "lower"),
+    ("concurrent_read_p95_ms", "Concurrent read p95", "lower"),
+    ("commit_p95_ms", "Commit p95", "lower"),
+    ("insert_rows_per_sec", "Insert throughput", "higher"),
+]
+
+REQUIRED_ENGINES = {
+    "decentdb_balanced_durable",
+    "decentdb_low_memory_durable",
+    "decentdb_tuned_durable",
+    "duckdb_engine_default",
+    "sqlite",
+}
+
+
+@dataclass(frozen=True)
+class RustBaselineRun:
+    path: Path
+    scale: str
+    profile: str
+    started_unix: int
+    engine_version: str
+    total_seconds: float
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"{path} is missing or invalid JSON: {error}") from error
+
+
+def as_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def speedup(base: float, value: float, direction: str) -> float | None:
+    if base <= 0.0 or value <= 0.0:
+        return None
+    if direction == "higher":
+        return value / base
+    return base / value
+
+
+def rust_baseline_runs(directory: Path) -> list[RustBaselineRun]:
+    if not directory.exists():
+        return []
+
+    runs: list[RustBaselineRun] = []
+    for path in sorted(directory.glob("*.json")):
+        document = load_json(path)
+        steps = document.get("steps", [])
+        if not isinstance(steps, list):
+            continue
+        total = 0.0
+        for step in steps:
+            if isinstance(step, dict):
+                total += float(step.get("duration_seconds") or 0.0)
+        runs.append(
+            RustBaselineRun(
+                path=path,
+                scale=str(document.get("scale_name", "")),
+                profile=str(document.get("benchmark_profile", "default")),
+                started_unix=int(document.get("started_unix", 0)),
+                engine_version=str(document.get("engine_version", "")),
+                total_seconds=total,
+            )
+        )
+    return runs
+
+
+def latest_rust_baseline_run(
+    directory: Path,
+    *,
+    scale: str,
+    profile: str,
+) -> RustBaselineRun | None:
+    matches = [
+        run
+        for run in rust_baseline_runs(directory)
+        if run.scale == scale and run.profile == profile
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda run: (run.started_unix, run.path.name))
+
+
+def validate_summary(
+    summary_path: Path,
+    *,
+    min_tuned_sqlite_wins: int,
+) -> tuple[list[str], list[str]]:
+    issues: list[str] = []
+    report: list[str] = []
+
+    summary = load_json(summary_path)
+    engines = summary.get("engines", {})
+    metadata = summary.get("metadata", {})
+    if not isinstance(engines, dict):
+        return ["benchmark summary does not contain an engines object"], report
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    missing = sorted(REQUIRED_ENGINES - set(engines))
+    if missing:
+        issues.append(
+            "benchmark summary is missing release engines: " + ", ".join(missing)
+        )
+        return issues, report
+
+    process_coordination = str(metadata.get("decentdb_process_coordination", ""))
+    if process_coordination != "single_process_unsafe":
+        issues.append(
+            "release README benchmark summary must mark DecentDB rows as "
+            "process_coordination=single_process_unsafe; got "
+            f"{process_coordination!r}"
+        )
+
+    for key in (
+        "decentdb_profile_balanced",
+        "decentdb_profile_default",
+        "decentdb_profile_low_memory",
+        "decentdb_profile_tuned",
+    ):
+        value = str(metadata.get(key, ""))
+        if "process_coordination=single_process_unsafe" not in value:
+            issues.append(
+                f"metadata[{key!r}] must include "
+                "process_coordination=single_process_unsafe"
+            )
+
+    sqlite = engines["sqlite"]
+    tuned = engines["decentdb_tuned_durable"]
+    if not isinstance(sqlite, dict) or not isinstance(tuned, dict):
+        issues.append("sqlite and decentdb_tuned_durable metrics must be objects")
+        return issues, report
+
+    wins = 0
+    metric_lines: list[str] = []
+    for key, label, direction in METRICS:
+        base = as_float(sqlite.get(key))
+        value = as_float(tuned.get(key))
+        if base is None or value is None:
+            metric_lines.append(f"- {label}: missing")
+            continue
+        ratio = speedup(base, value, direction)
+        if ratio is None:
+            metric_lines.append(f"- {label}: invalid base={base} value={value}")
+            continue
+        if ratio > 1.0:
+            wins += 1
+        metric_lines.append(f"- {label}: {ratio:.3f}x vs SQLite")
+
+    report.append("README chart release summary")
+    report.append(
+        "- benchmark family: cross-engine single-process embedded comparison"
+    )
+    report.append(f"- DecentDB process coordination: {process_coordination or 'missing'}")
+    report.append(
+        f"- DecentDB tuned durable wins: {wins}/{len(METRICS)} "
+        f"(minimum {min_tuned_sqlite_wins})"
+    )
+    report.extend(metric_lines)
+
+    if wins < min_tuned_sqlite_wins:
+        issues.append(
+            "decentdb_tuned_durable wins only "
+            f"{wins}/{len(METRICS)} README chart metrics vs SQLite; "
+            f"minimum is {min_tuned_sqlite_wins}. Do not publish a release "
+            "chart that communicates a severe tuned-profile degradation "
+            "without accepting and documenting that regression."
+        )
+
+    return issues, report
+
+
+def rust_baseline_report(
+    history_dir: Path,
+    current_dir: Path,
+    *,
+    scale: str,
+    profile: str,
+    max_current_vs_latest: float,
+) -> tuple[list[str], list[str]]:
+    issues: list[str] = []
+    report: list[str] = []
+
+    history = latest_rust_baseline_run(history_dir, scale=scale, profile=profile)
+    current = latest_rust_baseline_run(current_dir, scale=scale, profile=profile)
+    report.append("")
+    report.append("Rust raw-engine baseline cross-check")
+    report.append(f"- scale/profile: {scale}/{profile}")
+    if history is None:
+        report.append(f"- historical latest: missing under {history_dir}")
+        return issues, report
+    report.append(
+        f"- historical latest: {history.path.name} "
+        f"v{history.engine_version} total={history.total_seconds:.3f}s"
+    )
+    if current is None:
+        report.append(f"- current run: missing under {current_dir}")
+        return issues, report
+
+    ratio = (
+        current.total_seconds / history.total_seconds
+        if history.total_seconds > 0.0
+        else 0.0
+    )
+    report.append(
+        f"- current run: {current.path.name} "
+        f"v{current.engine_version} total={current.total_seconds:.3f}s"
+    )
+    report.append(f"- current/latest total ratio: {ratio:.3f}x")
+    if ratio > max_current_vs_latest:
+        issues.append(
+            "rust-baseline current total runtime is "
+            f"{ratio:.3f}x latest historical for {scale}/{profile}; "
+            f"maximum allowed is {max_current_vs_latest:.3f}x"
+        )
+
+    return issues, report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate release-facing benchmark narrative"
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=Path("data/bench_summary.json"),
+        help="Merged README benchmark summary",
+    )
+    parser.add_argument(
+        "--min-tuned-sqlite-wins",
+        type=int,
+        default=4,
+        help="Minimum README chart metrics where tuned DecentDB must beat SQLite",
+    )
+    parser.add_argument(
+        "--rust-baseline-history-dir",
+        type=Path,
+        default=Path("benchmarks/rust-baseline/results"),
+    )
+    parser.add_argument(
+        "--rust-baseline-current-dir",
+        type=Path,
+        default=Path(".tmp/rust-baseline-current"),
+    )
+    parser.add_argument("--rust-baseline-scale", default="full")
+    parser.add_argument("--rust-baseline-profile", default="default")
+    parser.add_argument(
+        "--max-rust-baseline-current-vs-latest",
+        type=float,
+        default=1.25,
+        help="Fail if current rust-baseline total exceeds latest historical by this ratio",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        help="Optional path to write the validation report",
+    )
+    args = parser.parse_args()
+
+    issues, report = validate_summary(
+        args.summary,
+        min_tuned_sqlite_wins=args.min_tuned_sqlite_wins,
+    )
+    baseline_issues, baseline_report = rust_baseline_report(
+        args.rust_baseline_history_dir,
+        args.rust_baseline_current_dir,
+        scale=args.rust_baseline_scale,
+        profile=args.rust_baseline_profile,
+        max_current_vs_latest=args.max_rust_baseline_current_vs_latest,
+    )
+    issues.extend(baseline_issues)
+    report.extend(baseline_report)
+
+    output = "\n".join(report) + "\n"
+    print(output, end="")
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(output, encoding="utf-8")
+
+    if issues:
+        print("Benchmark narrative validation failed:", file=sys.stderr)
+        for issue in issues:
+            print(f"- {issue}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Enhance the benchmark asset workflow by introducing automated safeguards to ensure the integrity of release performance charts.

Changes include:
- Implement a new validation step in `.github/workflows/benchmark-assets.yml` using `scripts/validate_release_benchmark_narrative.py` to prevent publishing conflicting benchmark data.
- Add a `rust-baseline` full-scale cross-check to the CI workflow to compare current performance against the engine baseline.
- Update DecentDB benchmark profiles to use `single_process_unsafe` coordination for consistent single-process embedded comparisons in README charts.
- Update documentation (README, benchmarking guide, and spec) to reflect the new benchmarking methodology and the purpose of the narrative guard.
- Update changelog to document these changes to the release benchmark lane.