### PR TITLE
fix(decentdb): implement Send/Sync for OsFileLock on Windows

### DIFF
--- a/crates/decentdb/src/vfs/os.rs
+++ b/crates/decentdb/src/vfs/os.rs
@@ -409,6 +409,20 @@ struct OsFileLock {
     len: u64,
 }
 
+// SAFETY: `OsFileLock` stores a borrowed Windows kernel file handle and byte
+// range metadata. The guard never dereferences the raw handle; it only passes
+// it back to `UnlockFileEx` when dropped. Windows file handles are valid to use
+// from any thread while the owning `File` remains open, and DecentDB's
+// coordination layer keeps the owning `OsVfsFile` alive for the guard lifetime.
+#[cfg(windows)]
+unsafe impl Send for OsFileLock {}
+
+// SAFETY: Shared references to `OsFileLock` do not mutate Rust-managed state.
+// Unlocking happens only through `Drop`, which requires unique ownership of the
+// guard, and delegates synchronization to the operating system.
+#[cfg(windows)]
+unsafe impl Sync for OsFileLock {}
+
 #[cfg(windows)]
 impl VfsFileLock for OsFileLock {}
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -137,6 +137,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Windows native release builds by making the process-coordination
+  byte-range lock guard explicitly `Send`/`Sync` under the documented Windows
+  handle lifetime invariant.
 - Fixed the native release benchmark lane so DecentDB README chart profiles
   explicitly run as single-process embedded comparisons with
   `process_coordination=single_process_unsafe`, while keeping durable


### PR DESCRIPTION
Ensure that `OsFileLock` can be safely transferred between threads and shared across threads by implementing `Send` and `Sync`. This resolves issues with Windows native release builds where the lock guard was previously restricted by thread-safety bounds.

The implementation includes safety documentation justifying the invariants: Windows file handles remain valid across threads as long as the owning `File` is open, and the coordination layer ensures the `OsVfsFile` outlives the lock guard.