### PR TITLE
build(dart): improve mobile build scripts for Android and iOS

### DIFF
--- a/bindings/dart/scripts/build_mobile_android.sh
+++ b/bindings/dart/scripts/build_mobile_android.sh
@@ -100,7 +100,13 @@ find_android_linker() {
     return 0
   fi
 
-  local ndk_home="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-${NDK_HOME:-}}}"
+  local ndk_home="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-${NDK_HOME:-${ANDROID_NDK_LATEST_HOME:-}}}}"
+  if [[ -z "$ndk_home" || ! -d "$ndk_home" ]]; then
+    local sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+    if [[ -n "$sdk_root" && -d "$sdk_root/ndk" ]]; then
+      ndk_home="$(find "$sdk_root/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+    fi
+  fi
   if [[ -z "$ndk_home" || ! -d "$ndk_home" ]]; then
     return 1
   fi
@@ -119,6 +125,33 @@ find_android_linker() {
   return 1
 }
 
+find_android_tool() {
+  local tool="$1"
+  local ndk_home="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-${NDK_HOME:-${ANDROID_NDK_LATEST_HOME:-}}}}"
+  if [[ -z "$ndk_home" || ! -d "$ndk_home" ]]; then
+    local sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+    if [[ -n "$sdk_root" && -d "$sdk_root/ndk" ]]; then
+      ndk_home="$(find "$sdk_root/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+    fi
+  fi
+  if [[ -z "$ndk_home" || ! -d "$ndk_home" ]]; then
+    return 1
+  fi
+
+  local host_tag="linux-x86_64"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    host_tag="darwin-$(uname -m)"
+  fi
+
+  local path="$ndk_home/toolchains/llvm/prebuilt/$host_tag/bin/$tool"
+  if [[ -x "$path" ]]; then
+    echo "$path"
+    return 0
+  fi
+
+  return 1
+}
+
 build_target() {
   local abi="$1"
   local target="$2"
@@ -131,8 +164,10 @@ build_target() {
   fi
 
   local target_suffix
+  local cc_suffix
   local env_var
   local linker
+  local ar
   local out_lib
   local dst_dir
   local env_args=()
@@ -142,11 +177,19 @@ build_target() {
 
   target_suffix="${target^^}"
   target_suffix="${target_suffix//-/_}"
+  cc_suffix="${target//-/_}"
   env_var="CARGO_TARGET_${target_suffix}_LINKER"
 
   linker="${!env_var:-$(find_android_linker "$target" || true)}"
   if [[ -n "$linker" ]]; then
-    env_args=("${env_var}=${linker}")
+    env_args=(
+      "${env_var}=${linker}"
+      "CC_${cc_suffix}=${linker}"
+    )
+    ar="$(find_android_tool llvm-ar || true)"
+    if [[ -n "$ar" ]]; then
+      env_args+=("AR_${cc_suffix}=${ar}")
+    fi
   else
     echo "::warning::No Android linker detected for $target. Build may fail if toolchain is unavailable."
     echo "Hint: export CARGO_TARGET_${target_suffix}_LINKER or set ANDROID_NDK_HOME/NDK_HOME."

--- a/bindings/dart/scripts/build_mobile_ios.sh
+++ b/bindings/dart/scripts/build_mobile_ios.sh
@@ -145,17 +145,17 @@ build_xcframework() {
   return 0
 }
 
-declare -a ABIS=(ios-arm64 ios-simulator-x86_64)
-declare -A ABI_TO_TARGET=(
-  [ios-arm64]=aarch64-apple-ios
-  [ios-simulator-x86_64]=x86_64-apple-ios
+declare -a TARGET_SPECS=(
+  "ios-arm64:aarch64-apple-ios"
+  "ios-simulator-x86_64:x86_64-apple-ios"
 )
 
-total_count=${#ABIS[@]}
+total_count=${#TARGET_SPECS[@]}
 built_count=0
 
-for abi in "${ABIS[@]}"; do
-  target="${ABI_TO_TARGET[$abi]}"
+for spec in "${TARGET_SPECS[@]}"; do
+  abi="${spec%%:*}"
+  target="${spec#*:}"
   if build_static_target "$abi" "$target"; then
     built_count=$((built_count + 1))
   fi

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -140,6 +140,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Windows native release builds by making the process-coordination
   byte-range lock guard explicitly `Send`/`Sync` under the documented Windows
   handle lifetime invariant.
+- Fixed mobile native artifact release builds by passing Android NDK compiler
+  and archiver paths through to C build scripts and avoiding Bash associative
+  arrays in the iOS artifact script on macOS runners.
 - Fixed the native release benchmark lane so DecentDB README chart profiles
   explicitly run as single-process embedded comparisons with
   `process_coordination=single_process_unsafe`, while keeping durable


### PR DESCRIPTION
Update Android build scripts to automatically locate the NDK and correctly pass the compiler (CC) and archiver (AR) paths to the build environment. This ensures proper toolchain usage during cross-compilation.

Refactor the iOS build script to use a more portable string-splitting approach instead of Bash associative arrays, improving compatibility with macOS runners.

Update the changelog to reflect these fixes in the mobile native artifact release process.