### PR TITLE
ci(mobile): enhance toolchain configuration for Android and iOS builds

### DIFF
--- a/bindings/dart/scripts/build_mobile_android.sh
+++ b/bindings/dart/scripts/build_mobile_android.sh
@@ -166,8 +166,10 @@ build_target() {
   local target_suffix
   local cc_suffix
   local env_var
+  local cflags_var
   local linker
   local ar
+  local existing_cflags
   local out_lib
   local dst_dir
   local env_args=()
@@ -179,12 +181,15 @@ build_target() {
   target_suffix="${target_suffix//-/_}"
   cc_suffix="${target//-/_}"
   env_var="CARGO_TARGET_${target_suffix}_LINKER"
+  cflags_var="CFLAGS_${cc_suffix}"
 
   linker="${!env_var:-$(find_android_linker "$target" || true)}"
   if [[ -n "$linker" ]]; then
+    existing_cflags="${!cflags_var:-}"
     env_args=(
       "${env_var}=${linker}"
       "CC_${cc_suffix}=${linker}"
+      "${cflags_var}=${existing_cflags:+$existing_cflags }-D_GNU_SOURCE -Wno-error=implicit-function-declaration"
     )
     ar="$(find_android_tool llvm-ar || true)"
     if [[ -n "$ar" ]]; then

--- a/bindings/dart/scripts/build_mobile_ios.sh
+++ b/bindings/dart/scripts/build_mobile_ios.sh
@@ -96,7 +96,7 @@ build_static_target() {
     return 2
   fi
 
-  if ! cargo rustc -p decentdb --crate-type staticlib --target "$target" "${CARGO_PROFILE[@]}"; then
+  if ! cargo rustc -p decentdb --lib --crate-type staticlib --target "$target" "${CARGO_PROFILE[@]}"; then
     echo "::warning::cargo rustc failed for $target, skipping $abi."
     return 1
   fi

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -140,9 +140,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Windows native release builds by making the process-coordination
   byte-range lock guard explicitly `Send`/`Sync` under the documented Windows
   handle lifetime invariant.
-- Fixed mobile native artifact release builds by passing Android NDK compiler
-  and archiver paths through to C build scripts and avoiding Bash associative
-  arrays in the iOS artifact script on macOS runners.
+- Fixed mobile native artifact release builds by passing Android NDK compiler,
+  archiver, and C flag settings through to C build scripts and avoiding Bash
+  associative arrays in the iOS artifact script on macOS runners.
 - Fixed the native release benchmark lane so DecentDB README chart profiles
   explicitly run as single-process embedded comparisons with
   `process_coordination=single_process_unsafe`, while keeping durable


### PR DESCRIPTION
Update Android build scripts to inject CFLAGS for improved compatibility with implicit function declarations and ensure proper toolchain usage. Adjust iOS build command to include the `--lib` flag when compiling the static library.

Update changelog to reflect the addition of C flag settings to the mobile build process.