### PR TITLE
build(mobile): improve Android NDK integration and CI script robustness

### DIFF
--- a/.github/workflows/mobile-native-artifacts.yml
+++ b/.github/workflows/mobile-native-artifacts.yml
@@ -64,16 +64,18 @@ jobs:
             --strict
 
       - name: Validate Android artifacts
-        run: bash bindings/dart/scripts/check_mobile_artifacts.sh \
-          --platform android \
-          --artifact-root "$MOBILE_ARTIFACT_ROOT" \
-          --strict
+        run: |
+          bash bindings/dart/scripts/check_mobile_artifacts.sh \
+            --platform android \
+            --artifact-root "$MOBILE_ARTIFACT_ROOT" \
+            --strict
 
       - name: Record Android guardrails
-        run: bash bindings/dart/scripts/mobile_benchmark_guardrails.sh \
-          --android-root "$MOBILE_ARTIFACT_ROOT" \
-          --ios-root "$RUNNER_TEMP/missing-ios" \
-          --output "$MOBILE_ARTIFACT_ROOT/mobile-guardrails.json"
+        run: |
+          bash bindings/dart/scripts/mobile_benchmark_guardrails.sh \
+            --android-root "$MOBILE_ARTIFACT_ROOT" \
+            --ios-root "$RUNNER_TEMP/missing-ios" \
+            --output "$MOBILE_ARTIFACT_ROOT/mobile-guardrails.json"
 
       - name: Package Android artifacts
         run: |
@@ -127,16 +129,18 @@ jobs:
             --strict
 
       - name: Validate iOS artifacts
-        run: bash bindings/dart/scripts/check_mobile_artifacts.sh \
-          --platform ios \
-          --artifact-root "$MOBILE_ARTIFACT_ROOT" \
-          --strict
+        run: |
+          bash bindings/dart/scripts/check_mobile_artifacts.sh \
+            --platform ios \
+            --artifact-root "$MOBILE_ARTIFACT_ROOT" \
+            --strict
 
       - name: Record iOS guardrails
-        run: bash bindings/dart/scripts/mobile_benchmark_guardrails.sh \
-          --android-root "$RUNNER_TEMP/missing-android" \
-          --ios-root "$MOBILE_ARTIFACT_ROOT" \
-          --output "$MOBILE_ARTIFACT_ROOT/mobile-guardrails.json"
+        run: |
+          bash bindings/dart/scripts/mobile_benchmark_guardrails.sh \
+            --android-root "$RUNNER_TEMP/missing-android" \
+            --ios-root "$MOBILE_ARTIFACT_ROOT" \
+            --output "$MOBILE_ARTIFACT_ROOT/mobile-guardrails.json"
 
       - name: Package iOS artifacts
         run: |

--- a/bindings/dart/scripts/build_mobile_android.sh
+++ b/bindings/dart/scripts/build_mobile_android.sh
@@ -152,6 +152,32 @@ find_android_tool() {
   return 1
 }
 
+find_android_sysroot() {
+  local ndk_home="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-${NDK_HOME:-${ANDROID_NDK_LATEST_HOME:-}}}}"
+  if [[ -z "$ndk_home" || ! -d "$ndk_home" ]]; then
+    local sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+    if [[ -n "$sdk_root" && -d "$sdk_root/ndk" ]]; then
+      ndk_home="$(find "$sdk_root/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)"
+    fi
+  fi
+  if [[ -z "$ndk_home" || ! -d "$ndk_home" ]]; then
+    return 1
+  fi
+
+  local host_tag="linux-x86_64"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    host_tag="darwin-$(uname -m)"
+  fi
+
+  local sysroot="$ndk_home/toolchains/llvm/prebuilt/$host_tag/sysroot"
+  if [[ -d "$sysroot" ]]; then
+    echo "$sysroot"
+    return 0
+  fi
+
+  return 1
+}
+
 build_target() {
   local abi="$1"
   local target="$2"
@@ -169,7 +195,9 @@ build_target() {
   local cflags_var
   local linker
   local ar
+  local sysroot
   local existing_cflags
+  local existing_bindgen_args
   local out_lib
   local dst_dir
   local env_args=()
@@ -186,11 +214,18 @@ build_target() {
   linker="${!env_var:-$(find_android_linker "$target" || true)}"
   if [[ -n "$linker" ]]; then
     existing_cflags="${!cflags_var:-}"
+    existing_bindgen_args="${BINDGEN_EXTRA_CLANG_ARGS:-}"
+    sysroot="$(find_android_sysroot || true)"
     env_args=(
       "${env_var}=${linker}"
       "CC_${cc_suffix}=${linker}"
       "${cflags_var}=${existing_cflags:+$existing_cflags }-D_GNU_SOURCE -Wno-error=implicit-function-declaration"
     )
+    if [[ -n "$sysroot" ]]; then
+      env_args+=(
+        "BINDGEN_EXTRA_CLANG_ARGS=${existing_bindgen_args:+$existing_bindgen_args }--target=${target} --sysroot=${sysroot} -I${sysroot}/usr/include -I${sysroot}/usr/include/${target}"
+      )
+    fi
     ar="$(find_android_tool llvm-ar || true)"
     if [[ -n "$ar" ]]; then
       env_args+=("AR_${cc_suffix}=${ar}")

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -141,8 +141,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   byte-range lock guard explicitly `Send`/`Sync` under the documented Windows
   handle lifetime invariant.
 - Fixed mobile native artifact release builds by passing Android NDK compiler,
-  archiver, and C flag settings through to C build scripts and avoiding Bash
-  associative arrays in the iOS artifact script on macOS runners.
+  archiver, C flag, and bindgen sysroot settings through to C build scripts,
+  using shell-safe multi-line workflow commands, and avoiding Bash associative
+  arrays in the iOS artifact script on macOS runners.
 - Fixed the native release benchmark lane so DecentDB README chart profiles
   explicitly run as single-process embedded comparisons with
   `process_coordination=single_process_unsafe`, while keeping durable


### PR DESCRIPTION
Implement automatic Android sysroot detection to provide necessary include paths and target information to bindgen. Refactor GitHub workflow steps to use multi-line shell syntax for improved readability and reliability.

Update changelog to reflect enhanced build script capabilities for mobile platforms.